### PR TITLE
fastlane: add DE locale, adjust formatting for EN fulldesc

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,14 @@
+Bei aktuellen Android-Versionen reicht der Doze-Modus aus, um den Stromverbrauch des Hintergrunds der Anwendung zu unterdrücken, aber einige fortgeschrittene Benutzer hoffen immer noch, den Wakelock selbst steuern zu können.
+
+Amplify ist gut genug, um die Bedürfnisse der meisten Menschen zu erfüllen, aber nach Android N stoppt Amplify die Aktualisierung. <i>NoWakeLock</i> erwartet also, die gleiche Funktion wie Amplify auf Android N und höher zu erreichen.
+
+<i>NoWakeLock</i> ist für Android N und höher verfügbar. Verwenden Sie für frühere Versionen von Android N bitte Amplify. Beide Apps benötigen root und das Xposed Framework.
+
+<b>Features</b>
+
+* Die Suchabfragen unterscheiden nicht zwischen Satzzeichen, diakritischen Zeichen und Groß-/Kleinschreibung
+* Sehen, welche Anwendungen Wakelock / Alarm / Service auslösen
+* Jegliches Wakelock blockieren
+* Jeglichen Alarm blockieren
+* Verhindern, dass ein Service ausgeführt wird
+* Möglichkeit, diese nur zu sperren, wenn der Bildschirm gesperrt ist

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Android-Wakelocks mit Open Source steuern

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,10 +1,10 @@
-**NoWakeLock** allows you to get control over Wakelocks, Services and Alarms
+<b>NoWakeLock</b> allows you to get control over Wakelocks, Services and Alarms
+
 With the update of Android version, doze mode is enough to suppress the power consumption of the background of the application, but some advanced users still hope to be able to control the wakelock by themselves.
 
-**Features**
+<b>Features</b>
 
-* Lookup queries are punctuation, diacritics and case
-insensitive.
+* Lookup queries are punctuation, diacritics and case insensitive.
 * See which apps are triggering Wakelock / Alarm / Service
 * Block any wakelock
 * Block any alarm


### PR DESCRIPTION
This PR adds the German locale (`de`), and adjusts the formatting of the English full description to also support sites which do not understand Markdown formatting.